### PR TITLE
Additional top 20 entries - easily identifiable schedulers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,4 +30,4 @@ Links to the Schedulers mentioned in these lists
 * [PBS/Torque](https://adaptivecomputing.com/cherry-services/torque-resource-manager/)
 * [SLURM](https://slurm.schedmd.com/documentation.html)
 * [Son of Grid Engine](https://sourceforge.net/projects/gridengine/) - community project to continue Sun's old gridengine 
-
+* [Univa Grid Engine](http://www.univa.com/products/)

--- a/top500.csv
+++ b/top500.csv
@@ -4,4 +4,11 @@ Sierra,IBM Spectrum LSF,https://hpc.llnl.gov/training/tutorials/using-lcs-sierra
 Sunway TaihuLight,SLURM (yhq),????,2019,https://www.top500.org/system/178764
 Frontera,SLURM,https://frontera-portal.tacc.utexas.edu/user-guide/running/,2019,https://www.top500.org/system/179607
 Piz Daint,SLURM,https://user.cscs.ch/access/running/,2019,https://www.top500.org/system/177824
+AI Bridging Cloud Infrastructure,Univa Grid Engine,https://docs.abci.ai/en/03/,2019,https://www.top500.org/system/179393
+SuperMUC-NG,SLURM,https://doku.lrz.de/display/PUBLIC/Job+Processing+with+SLURM+on+SuperMUC-NG,2019,https://www.top500.org/system/179566
+Lassen,IBM Spectrum LSF,https://hpc.llnl.gov/training/tutorials/using-lcs-sierra-system,2019,https://www.top500.org/system/179567
+Sequoia,SLURM,https://computing.llnl.gov/tutorials/bgq/,2019,https://www.top500.org/system/177556
+Cori,SLURM,https://docs.nersc.gov/jobs/,2019,https://www.top500.org/site/48429
+Stampede2,SLURM,https://portal.tacc.utexas.edu/user-guides/stampede2#running-slurm,2019,https://www.top500.org/system/179045
+Marconi,SLURM,https://wiki.u-gov.it/confluence/display/SCAIUS/UG3.1%3A+MARCONI+UserGuide#UG3.1:MARCONIUserGuide-Batch,2019,https://www.top500.org/system/178937
 MareNostrum 4,SLURM,https://www.bsc.es/user-support/mn4.php#runningjobs,2019,https://www.top500.org/system/179442


### PR DESCRIPTION
## Changes in this PR

Adds scheduler details for the leftover clusters in the top 20 (nov 2019 list) which had easily identifiable scheduler information in their user guides.

## Notes

- I believe Sequoia is now decommissioned. Should the list only account for active clusters?
- Cori: the user guide here is ambiguous, it seems to indicate that all NERSC clusters use SLURM (Cori specific details could not be found).